### PR TITLE
Add ALP to syscalls/ustat0[1|2]

### DIFF
--- a/ltp_known_issues.yaml
+++ b/ltp_known_issues.yaml
@@ -1,11 +1,11 @@
 ---
 syscalls:
     ustat01:
-    - product: opensuse:(Tumbleweed|15\.4)
+    - product: opensuse:(Tumbleweed|15\.4)|alp
       retval: ^1$
       message: ustat() is known to fail with EINVAL on Btrfs. Downstream fixes didn't make it to upstream and were removed. bsc#1194208
     ustat02:
-    - product: opensuse:(Tumbleweed|15\.4)
+    - product: opensuse:(Tumbleweed|15\.4)|alp
       retval: ^1$
       message: ustat() is known to fail with EINVAL on Btrfs. Downstream fixes didn't make it to upstream and were removed. bsc#1194208
 


### PR DESCRIPTION
Verification run:  http://10.100.12.105/tests/1859

LTP known issues feature is enabled in https://github.com/os-autoinst/opensuse-jobgroups/pull/212