### PR TITLE
Mark move_pages04 as known issue

### DIFF
--- a/ltp_known_issues.yaml
+++ b/ltp_known_issues.yaml
@@ -60,6 +60,13 @@ net.rpc_tests:
     - product: opensuse:(Tumbleweed|15\.[56])
       message: Unstable test. poo#38345
 
+numa:
+    move_pages04:
+    - product: opensuse:Tumbleweed
+      retval: ^1$
+      kernel: 6\.11
+      message: expected to fail for kernels <6.12 [https://lore.kernel.org/ltp/20241008135934.2491333-2-david@redhat.com/]
+
 syscalls:
     creat09:
     - product: opensuse:Tumbleweed


### PR DESCRIPTION
move_pages04 is expected to fail on kernels <6.12 due to wrong errno being returned.

https://lore.kernel.org/ltp/20241008135934.2491333-2-david@redhat.com/