### PR TITLE
LTP: Remove fixed entries (bsc#1218087, bsc#1217134)

### DIFF
--- a/ltp_known_issues.yaml
+++ b/ltp_known_issues.yaml
@@ -92,53 +92,12 @@ syscalls:
       retval: ^1$
       bugzilla: 1230922
       message: getdents fails for dir and symlink entries on bcachefs. Kernel bug. bsc#1230922
-    ioctl01:
-    - product: opensuse:Tumbleweed
-      arch: ppc64le$
-      retval: ^2$
-      message: ioctl(TCGETS) with invalid address triggers process SEGFAULT. Glibc syscall wrapper issue. WONTFIX. bsc#1217134
     ioctl_loop06:
     - product: opensuse:Tumbleweed
       arch: ppc64le$
       retval: ^1$
       bugzilla: 1230149
       message: ioctl(LOOP_SET_BLOCK_SIZE) and ioctl(LOOP_CONFIGURE) accept blocksize larger than pagesize on PPC64LE. Kernel bug. bsc#1230149
-    recvmmsg01:
-    - product: opensuse:Tumbleweed
-      ltp_version: ltp-32bit
-      retval: ^2$
-      message: glibc syscall wrapper function access the invalid pointer lead crash in 32-bit compatibility mode. WONTFIX bsc#1218087
-    - product: opensuse:Tumbleweed
-      arch: ^i586$
-      retval: ^2$
-      message: glibc syscall wrapper function access the invalid pointer lead crash in 32-bit compatibility mode. WONTFIX bsc#1218087
-    mq_timedreceive01:
-    - product: opensuse:Tumbleweed
-      ltp_version: ltp-32bit
-      retval: ^2$
-      message: glibc syscall wrapper function access the invalid pointer lead crash in 32-bit compatibility mode. WONTFIX bsc#1218087
-    - product: opensuse:Tumbleweed
-      arch: ^i586$
-      retval: ^2$
-      message: glibc syscall wrapper function access the invalid pointer lead crash in 32-bit compatibility mode. WONTFIX bsc#1218087
-    mq_timedsend01:
-    - product: opensuse:Tumbleweed
-      ltp_version: ltp-32bit
-      retval: ^2$
-      message: glibc syscall wrapper function access the invalid pointer lead crash in 32-bit compatibility mode. WONTFIX bsc#1218087
-    - product: opensuse:Tumbleweed
-      arch: ^i586$
-      retval: ^2$
-      message: glibc syscall wrapper function access the invalid pointer lead crash in 32-bit compatibility mode. WONTFIX bsc#1218087
-    sigtimedwait01:
-    - product: opensuse:Tumbleweed
-      ltp_version: ltp-32bit
-      retval: ^2$
-      message: glibc syscall wrapper function access the invalid pointer lead crash in 32-bit compatibility mode. WONTFIX bsc#1218087
-    - product: opensuse:Tumbleweed
-      arch: ^i586$
-      retval: ^2$
-      message: glibc syscall wrapper function access the invalid pointer lead crash in 32-bit compatibility mode. WONTFIX bsc#1218087
     statvfs01:
     - product: opensuse:Tumbleweed
       retval: ^1$


### PR DESCRIPTION
These tests were false positives and has been fixed in LTP upstream:

* ioctl01: https://github.com/linux-test-project/ltp/commit/ad651beeed393121ee541e3d07990e9a3d14c0c0
* mq_timedreceive01: https://github.com/linux-test-project/ltp/commit/37a806c8e5579f0ef4135c91a5ec483378e08163
* mq_timedsend01.c: https://github.com/linux-test-project/ltp/commit/57a9b1be34ecda4a055954998c253fda6b9e6460
* recvmmsg01: https://github.com/linux-test-project/ltp/commit/1d4d5a07505a09ae2692ccde4c07be97b7eab3fd
* sigtimedwait01.c: https://github.com/linux-test-project/ltp/commit/6dde3bc80fdbd97138ed85b56c5e5ed8acb2d621

@mdoucha @Avinesh FYI