### PR TITLE
LTP: Mark ima_selinux (poo#177396)

### DIFF
--- a/ltp_known_issues.yaml
+++ b/ltp_known_issues.yaml
@@ -12,6 +12,12 @@ cve:
       bugzilla: 1230065
       message: Invalid fsconfig() call passes on bcachefs. Kernel bug. bsc#1230065
 
+ima:
+    ima_selinux:
+    - product: opensuse:Tumbleweed
+      retval: ^1$
+      message: Likely bug in test. Work in progress. poo#177396
+
 kernel_misc:
     tpci:
     - skip: 1


### PR DESCRIPTION
@mdoucha @Avinesh FYI.

Test is skipped with `LTP_COMMAND_EXCLUDE=ima_selinux` in https://openqa.opensuse.org/admin/test_suites, I'll remove that setup after this is merged.