### PR TITLE
Revert "LTP: Mark lsmod01_sh on s390x (bsc#1237399)"

### DIFF
--- a/ltp_known_issues.yaml
+++ b/ltp_known_issues.yaml
@@ -1,13 +1,4 @@
 ---
-commands:
-    lsmod01_sh:
-    - product: opensuse:Tumbleweed
-      arch: s390x$
-      message: lsmod output difference from /proc/modules. Reported bsc#1237399
-      bugzilla: 1237399
-      retval: ^1$
-      keep_fail: 1
-
 cve:
     cve-2018-13405:
     - product: opensuse:Tumbleweed


### PR DESCRIPTION
This reverts commit 19d9329404883fd80d1dcc59dc2f5744304e3fc7. The issue was fixed in LTP[1]

[1] https://github.com/linux-test-project/ltp/commit/20aa359d20ec310f3aaa192e8a3fa8b3f81e55db