### PR TITLE
LTP: Whitelist known issues

### DIFF
--- a/ltp_known_issues.yaml
+++ b/ltp_known_issues.yaml
@@ -105,6 +105,26 @@ net.rpc_tests:
     rpc_xprt_unregister:
     - product: opensuse:(Tumbleweed|15\.[56])
       message: Unstable test. poo#38345
+    rpc_pmap_rmtcall:
+    - product: opensuse:Tumbleweed
+      message: Unstable test. poo#156595
+
+net.tirpc_tests:
+    tirpc_authdes_create:
+    - product: opensuse:Tumbleweed
+      message: Unstable test. poo#38345
+    tirpc_authdes_seccreate:
+    - product: opensuse:Tumbleweed
+      message: Unstable test. poo#38345
+    tirpc_rpc_broadcast:
+    - product: opensuse:Tumbleweed
+      message: Unstable test. poo#38345
+    tirpc_rpc_broadcast_exp:
+    - product: opensuse:Tumbleweed
+      message: Unstable test. poo#38345
+    tirpc_rpcb_rmtcall:
+    - product: opensuse:Tumbleweed
+      message: Unstable test. poo#156595
 
 numa:
     move_pages04:


### PR DESCRIPTION
Add known unstable tests:
- rpc_pmap_rmtcall
- tirpc_rpcb_rmtcall

Add the ones that were already excluded via LTP_COMMAND_EXCLUDE:
- tirpc_authdes_create
- tirpc_authdes_seccreate
- tirpc_rpc_broadcast
- tirpc_rpc_broadcast_exp