### PR TITLE
LTP: Document rpc rmtcall mask reason for completeness

### DIFF
--- a/ltp_known_issues.yaml
+++ b/ltp_known_issues.yaml
@@ -129,7 +129,7 @@ net.rpc_tests:
       message: Unstable test. poo#38345
     rpc_pmap_rmtcall:
     - product: opensuse:Tumbleweed
-      message: Unstable test. poo#156595
+      message: Test requires remote calls which are disabled by default in rpcbind package. poo#156595
 
 net.tirpc_tests:
     tirpc_authdes_create:
@@ -146,7 +146,7 @@ net.tirpc_tests:
       message: Unstable test. poo#38345
     tirpc_rpcb_rmtcall:
     - product: opensuse:Tumbleweed
-      message: Unstable test. poo#156595
+      message: Test requires remote calls which are disabled by default in rpcbind package. poo#156595
 
 numa:
     move_pages04:


### PR DESCRIPTION
This test was masked temporarily while I investigated the issue. It should stay masked.

Link: https://git.linux-nfs.org/?p=steved/rpcbind.git;a=commitdiff;h=2e9c289246c647e25649914bdb0d9400c66f486e
Link: https://build.opensuse.org/projects/network/packages/rpcbind/files/rpcbind.spec?expand=1