### PR TITLE
LTP: openposix: Mask non-compliant tests on Tumbleweed

### DIFF
--- a/ltp_known_issues.yaml
+++ b/ltp_known_issues.yaml
@@ -210,3 +210,17 @@ controllers:
     - product: opensuse:Tumbleweed
       skip: 1
       message: The test is hardcoded to run for 30+ minutes which is not worth the resource cost.
+
+openposix:
+    pthread_rwlock_rdlock_2-1:
+    - product: opensuse:Tumbleweed
+      retval: ^1$
+      message: Linux prefer readers by default while POSIX demands writers preference poo#181586
+    pthread_rwlock_rdlock_2-2:
+    - product: opensuse:Tumbleweed
+      retval: ^1$
+      message: Linux prefer readers by default while POSIX demands writers preference poo#181586
+    pthread_rwlock_unlock_3-1:
+    - product: opensuse:Tumbleweed
+      retval: ^1$
+      message: Linux prefer readers by default while POSIX demands writers preference poo#181586


### PR DESCRIPTION
These tests require the SUT to have a preference for writers, as demanded by POSIX. That is not the case for Linux with Glibc.

Link: https://lore.kernel.org/ltp/20250520-fixes-pthread_rwlock_rdlock-v1-1-402ee45114cc@suse.com/
Link: https://austingroupbugs.net/view.php?id=1111
Link: https://sourceware.org/bugzilla/show_bug.cgi?id=13701
Link: https://git.kernel.org/pub/scm/docs/man-pages/man-pages.git/tree/man/man3/pthread_rwlockattr_setkind_np.3?h=man-pages-6.14#n46

NOTE: The mentioned progress ticket is related to LTP_COMMAND_EXCLUDE, but the links mentioned in the commit should provide enough context anyway.