### PR TITLE
LTP: Don't skip bsc#1237069

### DIFF
--- a/ltp_known_issues.yaml
+++ b/ltp_known_issues.yaml
@@ -41,32 +41,26 @@ net.nfs:
     nfs10_v30_ip4t:
     - product: opensuse:Tumbleweed
       message: fsstress causes continuous workqueue and soft lockups. bsc#1237069
-      skip: 1
       arch: ppc64le$
     nfs10_v41_ip4t:
     - product: opensuse:Tumbleweed
       message: fsstress causes continuous workqueue and soft lockups. bsc#1237069
-      skip: 1
       arch: ppc64le$
     nfs10_v42_ip4t:
     - product: opensuse:Tumbleweed
       message: fsstress causes continuous workqueue and soft lockups. bsc#1237069
-      skip: 1
       arch: ppc64le$
     nfs10_v30_ip6t:
     - product: opensuse:Tumbleweed
       message: fsstress causes continuous workqueue and soft lockups. bsc#1237069
-      skip: 1
       arch: ppc64le$
     nfs10_v41_ip6t:
     - product: opensuse:Tumbleweed
       message: fsstress causes continuous workqueue and soft lockups. bsc#1237069
-      skip: 1
       arch: ppc64le$
     nfs10_v42_ip6t:
     - product: opensuse:Tumbleweed
       message: fsstress causes continuous workqueue and soft lockups. bsc#1237069
-      skip: 1
       arch: ppc64le$
     nfslock01_v30_ip4t:
     - product: opensuse:(Tumbleweed|15\.[4-6])


### PR DESCRIPTION
bsc#1237069 is claimed be fixed now, don't skip it (required for verification). Test still timeouts on ppc64le.

VR: https://openqa.opensuse.org/tests/overview?build=bcs1237069
- https://openqa.opensuse.org/tests/6071332 (ppc64le with nfs10.sh) 1 hours
- https://openqa.opensuse.org/tests/6071303 (ppc64le _without_ nfs10.sh) 2:11 hours
- https://openqa.opensuse.org/tests/6075638 (ppc64le with nfs10.sh and `LTP_ENV=TMPDIR=/var/tmp,LTP_NFS_NETNS_USE_LO=1`, haven't finished yet)

1) [`nfs10_v42_ip4t`](https://openqa.opensuse.org/tests/6071332#step/nfs10_v42_ip4t/12) causes kernel oops
2) Testsuite is running 2 hours (2x longer than without it).
3) https://bugzilla.suse.com/show_bug.cgi?id=1237069#c23 (based on https://bugzilla.suse.com/show_bug.cgi?id=1243697#c8) suggests
> making sure that PF_LOCAL_THROTTLE is set for veth should solve the issue

=> TODO debug with `LTP_ENV=LTP_NFS_NETNS_USE_LO=1`, maybe it should be set a default for nfs10.sh (at least on ppc64le). It looks to me actually as hiding a bug, but that's how labs see it, specially due https://bugzilla.suse.com/show_bug.cgi?id=1243697#c32
> There are a couple of related issues that I wanted
to look more deeply, but those are upstream issues and can be handled
independently in due course, there's no need to keep this bug around for
that.