### PR TITLE
Kselftests: BPF: Add whitelist for test_xsk.sh and kickstart test_progs

### DIFF
--- a/kselftests_known_issues.yaml
+++ b/kselftests_known_issues.yaml
@@ -1,1 +1,20 @@
 ---
+bpf:
+    SKB_XDP_METADATA_COPY:
+    - product: opensuse:Tumbleweed
+      message: Regression from new tail test. poo#188070
+    SKB_XDP_METADATA_COPY_MULTI_BUFF:
+    - product: opensuse:Tumbleweed
+      message: Regression from new tail test. poo#188070
+    SKB_XDP_ADJUST_TAIL_GROW:
+    - product: opensuse:Tumbleweed
+      message: New test. poo#188070
+    DRV_XDP_METADATA_COPY:
+    - product: opensuse:Tumbleweed
+      message: Regression from new tail test. poo#188070
+    DRV_XDP_METADATA_COPY_MULTI_BUFF:
+    - product: opensuse:Tumbleweed
+      message: Regression from new tail test. poo#188070
+    DRV_XDP_ADJUST_TAIL_GROW:
+    - product: opensuse:Tumbleweed
+      message: New test. poo#188070

--- a/kselftests_known_issues.yaml
+++ b/kselftests_known_issues.yaml
@@ -1,5 +1,6 @@
 ---
 bpf:
+    # test_xsk.sh
     SKB_XDP_METADATA_COPY:
     - product: opensuse:Tumbleweed
       message: Regression from new tail test. poo#188070
@@ -18,3 +19,11 @@ bpf:
     DRV_XDP_ADJUST_TAIL_GROW:
     - product: opensuse:Tumbleweed
       message: New test. poo#188070
+
+    # test_progs
+    test_tcp_ca_kfunc/tcp_ca_kfunc__open_and_load:
+    - product: opensuse:Tumbleweed
+      message: Configuration mismatch. poo#188076
+    bpf_tcp_ca/tcp_ca_kfunc:
+    - product: opensuse:Tumbleweed
+      message: Configuration mismatch. poo#188076

--- a/kselftests_known_issues.yaml
+++ b/kselftests_known_issues.yaml
@@ -19,6 +19,9 @@ bpf:
     DRV_XDP_ADJUST_TAIL_GROW:
     - product: opensuse:Tumbleweed
       message: New test. poo#188070
+    DRV_XDP_DROP_HALF:
+    - product: opensuse:Tumbleweed
+      message: Unstable test. poo#188073
 
     # test_progs
     test_tcp_ca_kfunc/tcp_ca_kfunc__open_and_load:


### PR DESCRIPTION
Related tickets:
- https://progress.opensuse.org/issues/188070
- https://progress.opensuse.org/issues/188073
- https://progress.opensuse.org/issues/188076