### PR TITLE
LTP: Whitelist ima_conditionals (poo#188250)

### DIFF
--- a/ltp_known_issues.yaml
+++ b/ltp_known_issues.yaml
@@ -12,6 +12,12 @@ cve:
       bugzilla: 1230065
       message: Invalid fsconfig() call passes on bcachefs. Kernel bug. bsc#1230065
 
+ima:
+    ima_conditionals:
+    - product: opensuse:Tumbleweed
+      retval: ^2$
+      message: User nobody can't be used with sudo. Bug in test or Tumbleweed setup. poo#188250
+
 kernel_misc:
     tpci:
     - skip: 1


### PR DESCRIPTION
https://progress.opensuse.org/issues/188250

failed to get algorithm/digest error is caused by broken sudo setup:

```
sudo: Account expired or PAM config lacks an "account" section for sudo, contact your system administrator
sudo: a password is required
ima_conditionals 1 TBROK: failed to get algorithm/digest for '/tmp/LTP_ima_conditionals.vplPdpfoDr/mntpoint/test.txt'
```