### PR TITLE
LTP: aarch64: riscv64: Mark bsc#1248286

### DIFF
--- a/ltp_known_issues.yaml
+++ b/ltp_known_issues.yaml
@@ -162,6 +162,14 @@ syscalls:
       ltp_version: ltp-32bit
       bugzilla: 1230280
       message: Test file was not deleted between subtests (EEXIST) on bcachefs. Kernel bug. bsc#1230280
+    epoll_wait02:
+    - product: opensuse:Tumbleweed
+      arch: ^(aarch64|riscv64)$
+      message: epoll_pwait() oversleeps by a random amount. bsc#1236868
+    epoll_pwait03:
+    - product: opensuse:Tumbleweed
+      arch: ^(aarch64|riscv64)$
+      message: epoll_pwait() oversleeps by a random amount. bsc#1236868
     fanotify09:
     - product: opensuse:15\.5
       retval: ^1$
@@ -186,6 +194,10 @@ syscalls:
       retval: ^1$
       bugzilla: 1230149
       message: ioctl(LOOP_SET_BLOCK_SIZE) and ioctl(LOOP_CONFIGURE) accept blocksize larger than pagesize on PPC64LE. Kernel bug. bsc#1230149
+    prctl09:
+    - product: opensuse:Tumbleweed
+      arch: riscv64$
+      message: Test reported to be too resource hungry for riscv64 software emulation. Maybe related to bsc#1236868
     statvfs01:
     - product: opensuse:Tumbleweed
       retval: ^1$


### PR DESCRIPTION
All 3 tests are failing on riscv64 emulation likely for the same reason as epoll_wait02 and epoll_pwait03 on aarch64 RPi bsc#1236868.

This is also a preparation to convert riscv64 skips to soft fails.  It was originally configured as skips in job setup: https://github.com/os-autoinst/opensuse-jobgroups/commit/dea11800d314a5dcc44279bdf87f3352ee4679e1 LTP_COMMAND_EXCLUDE: '(epoll_wait|epoll_pwait|select|prctl09).*' It will be removed there [1] after this is merged.

NOTE: All select* tests on riscv64 marked in [1] are working well, thus not marked here.  Problems are not timeouts (it does not help to increase current values on riscv64: LTP_TIMEOUT_MUL=2,LTP_RUNTIME_MUL=2).  Tests sometimes fail, but not always, therefore not skipped.

## aarch64
* epoll_pwait03
https://openqa.opensuse.org/tests/5346266#step/epoll_pwait03/6

```
tst_test.c:2008: TINFO: LTP version: 20250925.00c3e947
tst_test.c:2011: TINFO: Tested kernel: 6.16.8-1-default #1 SMP PREEMPT_DYNAMIC Fri Sep 19 16:56:17 UTC 2025 (051c8a7) aarch64
...
tst_timer_test.c:305: TINFO: min 100144us, max 101108us, median 100576us, trunc mean 100675.00us (discarded 1)
tst_timer_test.c:314: TFAIL: do_epoll_pwait() slept for too long
...
tst_timer_test.c:305: TINFO: min 1008931us, max 1010498us, median 1008931us, trunc mean 1008931.00us (discarded 1)
tst_timer_test.c:314: TFAIL: do_epoll_pwait() slept for too long
...
```

* epoll_wait02
https://openqa.opensuse.org/tests/5353947#step/epoll_wait02/8

```
tst_test.c:2021: TINFO: LTP version: 20250930.d2550ffb
tst_test.c:2024: TINFO: Tested kernel: 6.16.9-1-default #1 SMP PREEMPT_DYNAMIC Fri Sep 26 07:41:26 UTC 2025 (249a64d) aarch64
...
tst_timer_test.c:305: TINFO: min 25129us, max 25884us, median 25879us, trunc mean 25798.96us (discarded 2)
tst_timer_test.c:314: TFAIL: epoll_wait() slept for too long
```

## riscv64
* epoll_pwait03
https://openqa.opensuse.org/tests/5275100#step/epoll_pwait03/8

```
tst_test.c:2004: TINFO: LTP version: 20250827.2f465c71b
tst_test.c:2007: TINFO: Tested kernel: 6.16.3-1-default #1 SMP PREEMPT_DYNAMIC Tue Aug 26 05:31:27 UTC 2025 (b954ff4) riscv64
...
tst_timer_test.c:305: TINFO: min 10362us, max 10559us, median 10477us, trunc mean 10473.60us (discarded 5)
tst_timer_test.c:314: TFAIL: do_epoll_pwait() slept for too long
...
tst_timer_test.c:305: TINFO: min 25277us, max 25719us, median 25642us, trunc mean 25612.50us (discarded 2)
tst_timer_test.c:314: TFAIL: do_epoll_pwait() slept for too long
...
tst_timer_test.c:305: TINFO: min 100480us, max 101603us, median 100644us, trunc mean 100800.78us (discarded 1)
tst_timer_test.c:314: TFAIL: do_epoll_pwait() slept for too long
```

* epoll_wait02
https://openqa.opensuse.org/tests/5271296#step/epoll_wait02/8

```
tst_test.c:2004: TINFO: LTP version: 20250825.32e8ed57
tst_test.c:2007: TINFO: Tested kernel: 6.16.1-1-default #1 SMP PREEMPT_DYNAMIC Fri Aug 15 16:49:58 UTC 2025 (2e1765c) riscv64
...
tst_timer_test.c:263: TINFO: epoll_wait() sleeping for 1000us 500 iterations, threshold 450.01us
tst_timer_test.c:305: TINFO: min 1126us, max 1722us, median 1220us, trunc mean 1211.56us (discarded 25)
tst_timer_test.c:326: TPASS: Measured times are within thresholds
tst_timer_test.c:263: TINFO: epoll_wait() sleeping for 2000us 500 iterations, threshold 450.01us
tst_timer_test.c:305: TINFO: min 2160us, max 2448us, median 2228us, trunc mean 2218.46us (discarded 25)
tst_timer_test.c:326: TPASS: Measured times are within thresholds
```

* prctl09
https://openqa.opensuse.org/tests/5275100#step/prctl09/8

```
tst_test.c:2004: TINFO: LTP version: 20250827.2f465c71b
tst_test.c:2007: TINFO: Tested kernel: 6.16.3-1-default #1 SMP PREEMPT_DYNAMIC Tue Aug 26 05:31:27 UTC 2025 (b954ff4) riscv64
...
tst_timer_test.c:305: TINFO: min 100551us, max 100740us, median 100642us, trunc mean 100641.33us (discarded 1)
tst_timer_test.c:314: TFAIL: prctl() slept for too long
```

[1] https://github.com/os-autoinst/opensuse-jobgroups/pull/725
