### PR TITLE
Kselftests: BPF: Add `test_progs` known issues for Tumbleweed

### DIFF
--- a/kselftests_known_issues.yaml
+++ b/kselftests_known_issues.yaml
@@ -52,3 +52,10 @@ bpf:
     test_lsm:
     - product: opensuse:Tumbleweed
       message: SELinux makes mprotect() return EACCES. poo#188139
+
+    fs_kfuncs/security_selinux_xattr_error:
+    - product: opensuse:Tumbleweed
+      message: SELinux makes setxattr(f, "security.selinux", ...) return EINVAL. poo#188139
+    fs_kfuncs:
+    - product: opensuse:Tumbleweed
+      message: SELinux makes setxattr(f, "security.selinux", ...) return EINVAL. poo#188139

--- a/kselftests_known_issues.yaml
+++ b/kselftests_known_issues.yaml
@@ -30,3 +30,24 @@ bpf:
     bpf_tcp_ca/tcp_ca_kfunc:
     - product: opensuse:Tumbleweed
       message: Configuration mismatch. poo#188076
+
+    bpf_cookie/lsm:
+    - product: opensuse:Tumbleweed
+      message: SELinux makes mprotect() return EACCES. poo#188139
+    bpf_cookie:
+    - product: opensuse:Tumbleweed
+      message: SELinux makes mprotect() return EACCES. poo#188139
+
+    iters/css_task:
+    - product: opensuse:Tumbleweed
+      message: SELinux makes mprotect() return EACCES. poo#188139
+    iters:
+    - product: opensuse:Tumbleweed
+      message: SELinux makes mprotect() return EACCES. poo#188139
+
+    test_lsm/lsm_basic:
+    - product: opensuse:Tumbleweed
+      message: SELinux makes mprotect() return EACCES. poo#188139
+    test_lsm:
+    - product: opensuse:Tumbleweed
+      message: SELinux makes mprotect() return EACCES. poo#188139

--- a/kselftests_known_issues.yaml
+++ b/kselftests_known_issues.yaml
@@ -100,3 +100,10 @@ bpf:
     test_ima:
     - product: opensuse:Tumbleweed
       message: Configuration mismatch. poo#188244
+
+    kprobe_multi_test/attach_override:
+    - product: opensuse:Tumbleweed
+      message: Configuration mismatch. poo#188247
+    kprobe_multi_test:
+    - product: opensuse:Tumbleweed
+      message: Configuration mismatch. poo#188247

--- a/kselftests_known_issues.yaml
+++ b/kselftests_known_issues.yaml
@@ -139,3 +139,7 @@ bpf:
     token:
     - product: opensuse:Tumbleweed
       message: Configuration mismatch. poo#188313
+
+    verif_scale_pyperf600:
+    - product: opensuse:Tumbleweed
+      message: Program fails verification in LLVM 20. poo#188379

--- a/kselftests_known_issues.yaml
+++ b/kselftests_known_issues.yaml
@@ -59,3 +59,40 @@ bpf:
     fs_kfuncs:
     - product: opensuse:Tumbleweed
       message: SELinux makes setxattr(f, "security.selinux", ...) return EINVAL. poo#188139
+
+    tunnel/vxlan_tunnel:
+    - product: opensuse:Tumbleweed
+      message: Configuration mismatch. poo#188196
+    tunnel/ip6vxlan_tunnel:
+    - product: opensuse:Tumbleweed
+      message: Configuration mismatch. poo#188196
+    tunnel/ipip_tunnel:
+    - product: opensuse:Tumbleweed
+      message: Configuration mismatch. poo#188196
+    tunnel/xfrm_tunnel:
+    - product: opensuse:Tumbleweed
+      message: Configuration mismatch. poo#188196
+    tunnel/gre_tunnel:
+    - product: opensuse:Tumbleweed
+      message: Configuration mismatch. poo#188196
+    tunnel/ip6gre_tunnel:
+    - product: opensuse:Tumbleweed
+      message: Configuration mismatch. poo#188196
+    tunnel/erspan_tunnel:
+    - product: opensuse:Tumbleweed
+      message: Configuration mismatch. poo#188196
+    tunnel/ip6erspan_tunnel:
+    - product: opensuse:Tumbleweed
+      message: Configuration mismatch. poo#188196
+    tunnel/geneve_tunnel:
+    - product: opensuse:Tumbleweed
+      message: Configuration mismatch. poo#188196
+    tunnel/ip6geneve_tunnel:
+    - product: opensuse:Tumbleweed
+      message: Configuration mismatch. poo#188196
+    tunnel/ip6tnl_tunnel:
+    - product: opensuse:Tumbleweed
+      message: Configuration mismatch. poo#188196
+    tunnel:
+    - product: opensuse:Tumbleweed
+      message: Configuration mismatch. poo#188196

--- a/kselftests_known_issues.yaml
+++ b/kselftests_known_issues.yaml
@@ -114,3 +114,28 @@ bpf:
     libbpf_probe_prog_types:
     - product: opensuse:Tumbleweed
       message: Configuration mismatch. poo#188253
+
+    token/obj_priv_map:
+    - product: opensuse:Tumbleweed
+      message: Configuration mismatch. poo#188313
+    token/obj_priv_prog:
+    - product: opensuse:Tumbleweed
+      message: Configuration mismatch. poo#188313
+    token/obj_priv_freplace_prog:
+    - product: opensuse:Tumbleweed
+      message: Configuration mismatch. poo#188313
+    token/obj_priv_freplace_prog_fail:
+    - product: opensuse:Tumbleweed
+      message: Configuration mismatch. poo#188313
+    token/obj_priv_btf_success:
+    - product: opensuse:Tumbleweed
+      message: Configuration mismatch. poo#188313
+    token/obj_priv_implicit_token:
+    - product: opensuse:Tumbleweed
+      message: Configuration mismatch. poo#188313
+    token/obj_priv_implicit_token_envvar:
+    - product: opensuse:Tumbleweed
+      message: Configuration mismatch. poo#188313
+    token:
+    - product: opensuse:Tumbleweed
+      message: Configuration mismatch. poo#188313

--- a/kselftests_known_issues.yaml
+++ b/kselftests_known_issues.yaml
@@ -24,10 +24,11 @@ bpf:
       message: Unstable test. poo#188073
 
     # test_progs
-    test_tcp_ca_kfunc/tcp_ca_kfunc__open_and_load:
+
+    bpf_tcp_ca/tcp_ca_kfunc:
     - product: opensuse:Tumbleweed
       message: Configuration mismatch. poo#188076
-    bpf_tcp_ca/tcp_ca_kfunc:
+    bpf_tcp_ca:
     - product: opensuse:Tumbleweed
       message: Configuration mismatch. poo#188076
 

--- a/kselftests_known_issues.yaml
+++ b/kselftests_known_issues.yaml
@@ -107,3 +107,10 @@ bpf:
     kprobe_multi_test:
     - product: opensuse:Tumbleweed
       message: Configuration mismatch. poo#188247
+
+    libbpf_probe_prog_types/BPF_PROG_TYPE_LIRC_MODE2:
+    - product: opensuse:Tumbleweed
+      message: Configuration mismatch. poo#188253
+    libbpf_probe_prog_types:
+    - product: opensuse:Tumbleweed
+      message: Configuration mismatch. poo#188253

--- a/kselftests_known_issues.yaml
+++ b/kselftests_known_issues.yaml
@@ -96,3 +96,7 @@ bpf:
     tunnel:
     - product: opensuse:Tumbleweed
       message: Configuration mismatch. poo#188196
+
+    test_ima:
+    - product: opensuse:Tumbleweed
+      message: Configuration mismatch. poo#188244


### PR DESCRIPTION
Related ticket: https://progress.opensuse.org/issues/187791