### PR TITLE
LTP: remove nfs40 entries

### DIFF
--- a/ltp_known_issues.yaml
+++ b/ltp_known_issues.yaml
@@ -43,11 +43,6 @@ net.nfs:
       message: fsstress causes continuous workqueue and soft lockups. bsc#1237069
       skip: 1
       arch: ppc64le$
-    nfs10_v40_ip4t:
-    - product: opensuse:Tumbleweed
-      message: fsstress causes continuous workqueue and soft lockups. bsc#1237069
-      skip: 1
-      arch: ppc64le$
     nfs10_v41_ip4t:
     - product: opensuse:Tumbleweed
       message: fsstress causes continuous workqueue and soft lockups. bsc#1237069
@@ -59,11 +54,6 @@ net.nfs:
       skip: 1
       arch: ppc64le$
     nfs10_v30_ip6t:
-    - product: opensuse:Tumbleweed
-      message: fsstress causes continuous workqueue and soft lockups. bsc#1237069
-      skip: 1
-      arch: ppc64le$
-    nfs10_v40_ip6t:
     - product: opensuse:Tumbleweed
       message: fsstress causes continuous workqueue and soft lockups. bsc#1237069
       skip: 1


### PR DESCRIPTION
these are being covered by the recently added entry to skip all nfs4.0 tests under net.nfs [0]

[0] https://github.com/openSUSE/kernel-qe/commit/b8ff7ee353e1e84a0d2dcdaec893773b32ef76f2