### PR TITLE
Kselftests: BPF: Mark bpf_smc/topo as a known config mismatch

### DIFF
--- a/kselftests_known_issues.yaml
+++ b/kselftests_known_issues.yaml
@@ -125,6 +125,13 @@ bpf:
     - product: opensuse:Tumbleweed
       message: Configuration mismatch. Test requires CONFIG_NF_FLOW_TABLE=y. poo#188409
 
+    bpf_smc/topo:
+    - product: opensuse:Tumbleweed
+      message: Configuration mismatch. Test requires CONFIG_DIBS_LO=y.
+    bpf_smc:
+    - product: opensuse:Tumbleweed
+      message: Configuration mismatch. Test requires CONFIG_DIBS_LO=y.
+
     htab_update/reenter_update:
     - product: opensuse:Tumbleweed
       message: Configuration mismatch. Test requires CONFIG_FORTIFY_SOURCE=n. poo#188394


### PR DESCRIPTION
CONFIG_DIBS_LO (SMC-D loopback ISM device) is disabled on the Tumbleweed test kernel, so every SMC connection in test_topo falls back to plain TCP and the fallback-count assertion (which expects exactly one fallback) never holds.