### PR TITLE
Kselftests: Remove SELinux issues

### DIFF
--- a/kselftests_known_issues.yaml
+++ b/kselftests_known_issues.yaml
@@ -112,34 +112,6 @@ bpf:
     - product: opensuse:Tumbleweed
       message: Configuration mismatch. Test requires CONFIG_RANDOM_KMALLOC_CACHES=n. poo#188769
 
-    bpf_cookie/lsm:
-    - product: opensuse:Tumbleweed
-      message: SELinux makes mprotect() return EACCES. poo#188139
-    bpf_cookie:
-    - product: opensuse:Tumbleweed
-      message: SELinux makes mprotect() return EACCES. poo#188139
-
-    iters/css_task:
-    - product: opensuse:Tumbleweed
-      message: SELinux makes mprotect() return EACCES. poo#188139
-    iters:
-    - product: opensuse:Tumbleweed
-      message: SELinux makes mprotect() return EACCES. poo#188139
-
-    test_lsm/lsm_basic:
-    - product: opensuse:Tumbleweed
-      message: SELinux makes mprotect() return EACCES. poo#188139
-    test_lsm:
-    - product: opensuse:Tumbleweed
-      message: SELinux makes mprotect() return EACCES. poo#188139
-
-    fs_kfuncs/security_selinux_xattr_error:
-    - product: opensuse:Tumbleweed
-      message: SELinux makes setxattr(f, "security.selinux", ...) return EINVAL. poo#188139
-    fs_kfuncs:
-    - product: opensuse:Tumbleweed
-      message: SELinux makes setxattr(f, "security.selinux", ...) return EINVAL. poo#188139
-
     ns_bpf_qdisc:
     - product: opensuse:Tumbleweed
       message: Virtualized SUT veth interface is limited to a single queue. poo#188397


### PR DESCRIPTION
This has been dealt with in the test runner:

https://github.com/os-autoinst/os-autoinst-distri-opensuse/blob/ecce765b7d12705a2e719dd61367d6d9b7eb478e/lib/Kselftests/utils.pm#L185