### PR TITLE
Kselftests: net/mptcp: Generalize simult_flows_sh

### DIFF
--- a/kselftests_known_issues.yaml
+++ b/kselftests_known_issues.yaml
@@ -210,8 +210,9 @@ net:
       message: Environment setup problem. Issue not reproducible under strict selftests environment.
 
 net/mptcp:
-    simult_flows_sh:
-    - product: opensuse:Tumbleweed
+    '*':
+    - test: '^- simult_flows:'
+      product: opensuse:Tumbleweed
       message: >
         Unstable test.
         https://github.com/multipath-tcp/mptcp_net-next/issues/475


### PR DESCRIPTION
The subtests are not being triggered [1]. Use the wildcard pattern instead.

[1]: https://openqa.opensuse.org/tests/6090872#step/simult_flows_sh/7