### PR TITLE
Kselftests: BPF: Remove perf_branches

### DIFF
--- a/kselftests_known_issues.yaml
+++ b/kselftests_known_issues.yaml
@@ -101,13 +101,6 @@ bpf:
     - product: opensuse:Tumbleweed
       message: Configuration mismatch. Test requires CONFIG_FORTIFY_SOURCE=n. poo#188394
 
-    perf_branches/perf_branches_no_hw:
-    - product: opensuse:Tumbleweed
-      message: Configuration mismatch. Test requires CONFIG_RANDOM_KMALLOC_CACHES=n. poo#188766
-    perf_branches:
-    - product: opensuse:Tumbleweed
-      message: Configuration mismatch. Test requires CONFIG_RANDOM_KMALLOC_CACHES=n. poo#188766
-
     verifier_private_stack:
     - product: opensuse:Tumbleweed
       message: Configuration mismatch. Test requires CONFIG_RANDOM_KMALLOC_CACHES=n. poo#188769


### PR DESCRIPTION
This has been fixed in commit ae24fc8a16b0 ("selftests/bpf: Improve reliability of test_perf_branches_no_hw()") [1].

[1]: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=ae24fc8a16b0481ea8c5acbc66453c49ec0431c4