### PR TITLE
LTP: remove stale ustat entries

### DIFF
--- a/ltp_known_issues.yaml
+++ b/ltp_known_issues.yaml
@@ -124,14 +124,6 @@ syscalls:
     - product: opensuse:Tumbleweed
       arch: riscv64$
       message: Test reported to be too resource hungry for riscv64 software emulation. Maybe related to bsc#1236868
-    ustat01:
-    - product: opensuse:(Tumbleweed|15\.[4-6])
-      retval: ^1$
-      message: ustat() is known to fail with EINVAL on Btrfs. Downstream fixes didn't make it to upstream and were removed. bsc#1194208
-    ustat02:
-    - product: opensuse:(Tumbleweed|15\.[4-6])
-      retval: ^1$
-      message: ustat() is known to fail with EINVAL on Btrfs. Downstream fixes didn't make it to upstream and were removed. bsc#1194208
 
 tracing:
     ftrace-stress-test:


### PR DESCRIPTION
ustat[01|02] tests were updated to skip them on btrfs filesystem as these are not supported [0]

[0] https://github.com/linux-test-project/ltp/commit/3a4bf67d82eae0febb5462077fb43937e875e46e