### PR TITLE
blktests: Exclude loop/006 on Tumbleweed

### DIFF
--- a/blktests_known_issues.yaml
+++ b/blktests_known_issues.yaml
@@ -1,3 +1,7 @@
 ---
 
 blktests:
+  loop/006:
+  - product: opensuse:Tumbleweed
+    skip: 1
+    message: Unstable, makes udev too busy. poo#204738


### PR DESCRIPTION
Test makes udev too busy in some runs. poo#204738