### PR TITLE
Kselftests: BPF: Remove test_xdp_features_sh

### DIFF
--- a/kselftests_known_issues.yaml
+++ b/kselftests_known_issues.yaml
@@ -4,10 +4,6 @@ bpf:
     - product: opensuse:Tumbleweed
       message: Configuration mismatch. Test requires CONFIG_BPF_LIRC_MODE2=y
 
-    test_xdp_features_sh:
-    - product: opensuse:Tumbleweed
-      message: Test passes locally but fails in openQA, therefore there is a missing setting in the SUT.
-
     # test_xsk.sh
     SKB_XDP_ADJUST_TAIL_GROW:
     - product: opensuse:Tumbleweed


### PR DESCRIPTION
The test does not fail anymore https://openqa.opensuse.org/tests/6152312#step/test_xdp_features_sh/1